### PR TITLE
Add FastAPI prototype for LLM NPC village

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# LLM Village Prototype
+
+LLM 기반 농촌 마을 시뮬레이션을 웹앱 형태로 빠르게 체험할 수 있는 프로토타입입니다. FastAPI 백엔드와 간단한 정적 프론트엔드를 제공하며, NPC들은 체력·스태미너·배고픔·호감도 스탯을 바탕으로 간단한 규칙형 대화를 주고받습니다.
+
+## 주요 특징
+
+- **NPC 스탯 관리**: 각 NPC는 체력(HP), 스태미너, 배고픔, 호감도를 보유하며 시간 경과에 따라 수치가 변합니다.
+- **LLM 대화 모사**: 실제 LLM 대신, NPC 역할과 현재 스탯을 기반으로 상황에 맞는 대사를 생성하는 휴리스틱 로직을 구현했습니다.
+- **마을 이벤트 루프**: 시간 경과 API를 호출하면 NPC 간 자동 대화와 스탯 변화가 발생합니다.
+- **간단한 웹 UI**: `/frontend/index.html`을 통해 NPC 상태와 대화 로그를 확인하고 플레이어가 직접 대화를 시도할 수 있습니다.
+
+## 프로젝트 구조
+
+```
+app/
+  __init__.py        # FastAPI 앱 익스포트
+  main.py            # REST API 엔드포인트 정의
+  models.py          # NPC 및 대화 로그 데이터 모델
+  state.py           # 인메모리 시뮬레이션 상태 및 로직
+frontend/
+  index.html         # 정적 관찰/상호작용 페이지
+requirements.txt     # FastAPI 실행에 필요한 의존성 목록
+README.md            # 이 문서
+```
+
+## 실행 방법
+
+1. 가상 환경을 생성하고 의존성을 설치합니다.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. 개발 서버를 실행합니다.
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. 브라우저에서 `frontend/index.html` 파일을 열거나, 정적 서버를 띄워 API(`http://127.0.0.1:8000/api/...`)와 연동합니다.
+
+## 사용 가능한 API
+
+| Method | Endpoint                 | 설명 |
+|--------|--------------------------|------|
+| GET    | `/api/npcs`              | NPC 목록과 현재 스탯 조회 |
+| GET    | `/api/logs?limit=40`     | 최근 대화 로그 조회 |
+| POST   | `/api/interactions/user` | 플레이어가 NPC에게 말을 걸고 답변 획득 |
+| POST   | `/api/simulate/tick`     | 마을 시간을 한 스텝(또는 여러 스텝) 진행 |
+| POST   | `/api/admin/reset`       | 시뮬레이션 초기화 |
+
+각 엔드포인트는 JSON을 반환하며, 간단한 프로토타입 시나리오 테스트에 활용할 수 있습니다.
+
+## 차후 확장 아이디어
+
+- 실제 LLM(OpenAI 등)과 연동하여 NPC 대사를 생성
+- Supabase 등 외부 DB에 NPC 스탯과 로그를 저장해 세션 간 상태 유지
+- Pygame 또는 WebGL 기반의 시각적 마을 맵 렌더링 추가
+- 멀티 유저 접속을 위한 WebSocket 실시간 통신 적용
+
+---
+
+이 프로토타입을 바탕으로 LLM NPC 마을 콘셉트를 빠르게 검증하고, 필요한 기능을 단계적으로 확장해 나갈 수 있습니다.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""LLM Village prototype package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,59 @@
+"""FastAPI entry point for the LLM village prototype."""
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .state import STATE
+
+
+class UserInteractionRequest(BaseModel):
+    npc_id: str = Field(..., description="Identifier of the NPC to talk to")
+    message: str = Field(..., min_length=1, description="Player utterance")
+
+
+class AdvanceTimeRequest(BaseModel):
+    steps: int = Field(1, ge=1, le=24, description="Number of time slices to advance")
+
+
+app = FastAPI(title="LLM Village Prototype", version="0.1.0")
+
+
+@app.get("/api/npcs")
+def list_npcs() -> dict:
+    """Return the current NPC roster and stats."""
+
+    return {"npcs": STATE.serialise_npcs()}
+
+
+@app.get("/api/logs")
+def list_logs(limit: int | None = None) -> dict:
+    """Return recent dialogue logs."""
+
+    return {"logs": STATE.serialise_logs(limit=limit)}
+
+
+@app.post("/api/interactions/user")
+def interact_with_npc(payload: UserInteractionRequest) -> dict:
+    """Apply the player's message to the NPC and return the response."""
+
+    try:
+        result = STATE.apply_user_interaction(payload.npc_id, payload.message)
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return result
+
+
+@app.post("/api/simulate/tick")
+def advance_time(payload: AdvanceTimeRequest) -> dict:
+    """Advance the simulation by the requested number of steps."""
+
+    return STATE.advance_time(payload.steps)
+
+
+@app.post("/api/admin/reset")
+def reset_state() -> dict:
+    """Reset the in-memory state to the initial scenario."""
+
+    STATE.reset()
+    return {"status": "ok"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,89 @@
+"""Domain models for the LLM village prototype."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class Mood(str, Enum):
+    """Represents the high level emotion derived from NPC stats."""
+
+    HAPPY = "happy"
+    NEUTRAL = "neutral"
+    TIRED = "tired"
+    HUNGRY = "hungry"
+    EXHAUSTED = "exhausted"
+
+
+@dataclass
+class NPC:
+    """Data container with lightweight behaviour helpers for an NPC."""
+
+    npc_id: str
+    name: str
+    role: str
+    hp: int = 100
+    stamina: int = 100
+    hunger: int = 0
+    affection: int = 0
+    personality: str = ""
+    biography: str = ""
+    last_dialogue: Optional[datetime] = None
+    dialog_history: List[int] = field(default_factory=list)
+
+    def derive_mood(self) -> Mood:
+        """Return the NPC mood calculated from its stats."""
+
+        if self.stamina < 20 or self.hp < 20:
+            return Mood.EXHAUSTED
+        if self.hunger > 80:
+            return Mood.HUNGRY
+        if self.stamina < 50:
+            return Mood.TIRED
+        if self.affection > 40 and self.hunger < 30:
+            return Mood.HAPPY
+        return Mood.NEUTRAL
+
+    def apply_daily_decay(self) -> None:
+        """Update stats to simulate time passing."""
+
+        # Hunger increases gradually while stamina recovers when possible.
+        self.hunger = min(100, self.hunger + 10)
+        if self.hunger > 70:
+            self.stamina = max(0, self.stamina - 15)
+        else:
+            self.stamina = min(100, self.stamina + 10)
+        # HP regenerates slowly if hunger is manageable.
+        if self.hunger < 60:
+            self.hp = min(100, self.hp + 5)
+        else:
+            self.hp = max(0, self.hp - 5)
+
+    def adjust_affection(self, delta: int) -> None:
+        """Apply affection delta with soft bounds."""
+
+        self.affection = max(-100, min(100, self.affection + delta))
+
+
+@dataclass
+class DialogueLog:
+    """Represents a single line of conversation in the village."""
+
+    timestamp: datetime
+    speaker_id: str
+    target_id: Optional[str]
+    message: str
+    tags: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Convert the entry to a serialisable mapping."""
+
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "speaker_id": self.speaker_id,
+            "target_id": self.target_id,
+            "message": self.message,
+            "tags": self.tags,
+        }

--- a/app/state.py
+++ b/app/state.py
@@ -1,0 +1,253 @@
+"""In-memory simulation state for the LLM village prototype."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+import random
+from typing import Dict, List, Optional
+
+from .models import DialogueLog, Mood, NPC
+
+
+POSITIVE_KEYWORDS = {
+    "감사", "고마", "멋져", "좋", "사랑", "행복", "도와", "친절",
+}
+NEGATIVE_KEYWORDS = {
+    "싫", "나쁘", "화나", "짜증", "귀찮", "실망", "못해",
+}
+
+
+def _create_initial_npcs() -> Dict[str, NPC]:
+    """Return a deterministic set of prototype NPCs."""
+
+    return {
+        "astro": NPC(
+            npc_id="astro",
+            name="별이",
+            role="점성술사",
+            personality="차분하고 신비로운 말투로 상대를 위로함",
+            biography="마을의 별점을 책임지는 점성술사. 매일 새벽 별자리를 읽는다.",
+            hunger=20,
+        ),
+        "shopkeeper": NPC(
+            npc_id="shopkeeper",
+            name="다온",
+            role="상점 주인",
+            personality="장난기 있지만 장사에는 진지함",
+            biography="작은 잡화점을 운영하며 마을 경제를 챙긴다.",
+            stamina=80,
+        ),
+        "chief": NPC(
+            npc_id="chief",
+            name="하람",
+            role="촌장",
+            personality="차분하지만 결정이 빠른 지도자",
+            biography="마을 사람들의 의견을 모아 축제를 기획한다.",
+        ),
+    }
+
+
+class GameState:
+    """Mutable state container for the web simulation."""
+
+    def __init__(self) -> None:
+        self.npcs: Dict[str, NPC] = _create_initial_npcs()
+        self.logs: List[DialogueLog] = []
+        self.day: int = 1
+        self.time_slice: int = 0
+        random.seed(42)
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+    def serialise_npcs(self) -> List[Dict[str, object]]:
+        """Return NPCs as dictionaries for the API."""
+
+        return [
+            {
+                **asdict(npc),
+                "mood": npc.derive_mood().value,
+                "last_dialogue": npc.last_dialogue.isoformat()
+                if npc.last_dialogue
+                else None,
+            }
+            for npc in self.npcs.values()
+        ]
+
+    def serialise_logs(self, limit: Optional[int] = None) -> List[Dict[str, object]]:
+        """Return the most recent conversation entries."""
+
+        entries = self.logs[-limit:] if limit else self.logs
+        return [log.to_dict() for log in entries]
+
+    # ------------------------------------------------------------------
+    # Simulation operations
+    # ------------------------------------------------------------------
+    def record_dialogue(
+        self,
+        speaker_id: str,
+        message: str,
+        target_id: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Append a dialogue log entry and update metadata."""
+
+        now = datetime.utcnow()
+        entry = DialogueLog(
+            timestamp=now,
+            speaker_id=speaker_id,
+            target_id=target_id,
+            message=message,
+            tags=tags or {},
+        )
+        self.logs.append(entry)
+        if speaker_id in self.npcs:
+            self.npcs[speaker_id].last_dialogue = now
+            self.npcs[speaker_id].dialog_history.append(len(self.logs) - 1)
+        if target_id and target_id in self.npcs:
+            self.npcs[target_id].dialog_history.append(len(self.logs) - 1)
+
+    def apply_user_interaction(self, npc_id: str, message: str) -> Dict[str, object]:
+        """Update NPC state according to a user message and produce a reply."""
+
+        if npc_id not in self.npcs:
+            raise KeyError(f"Unknown NPC id: {npc_id}")
+
+        npc = self.npcs[npc_id]
+        affection_delta = self._estimate_affection_delta(message)
+        npc.adjust_affection(affection_delta)
+        npc.stamina = max(0, npc.stamina - 5)
+        npc.hunger = min(100, npc.hunger + 3)
+
+        reply = self._generate_npc_reply(npc, message, affection_delta)
+        self.record_dialogue("player", message, npc_id, tags={"type": "user"})
+        self.record_dialogue(npc_id, reply, "player", tags={"type": "npc"})
+
+        return {
+            "reply": reply,
+            "affection_change": affection_delta,
+            "npc": {
+                **asdict(npc),
+                "mood": npc.derive_mood().value,
+                "last_dialogue": npc.last_dialogue.isoformat()
+                if npc.last_dialogue
+                else None,
+            },
+        }
+
+    def advance_time(self, steps: int = 1) -> Dict[str, object]:
+        """Advance the simulation by a number of steps."""
+
+        summaries: List[str] = []
+        for _ in range(steps):
+            self.time_slice += 1
+            if self.time_slice % 4 == 0:
+                self.day += 1
+                self._new_day_reset()
+            self._npc_background_conversations()
+            self._apply_stat_changes()
+            summaries.append(
+                f"시간이 흘러 현재 {self.day}일차 {self.time_slice % 4}번째 시간입니다."
+            )
+        return {
+            "day": self.day,
+            "time_slice": self.time_slice,
+            "summaries": summaries,
+        }
+
+    def reset(self) -> None:
+        """Restore the initial state."""
+
+        self.__init__()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _estimate_affection_delta(self, message: str) -> int:
+        """Heuristic scoring to emulate a lightweight sentiment check."""
+
+        lowered = message.lower()
+        pos_hits = sum(keyword in lowered for keyword in POSITIVE_KEYWORDS)
+        neg_hits = sum(keyword in lowered for keyword in NEGATIVE_KEYWORDS)
+        return max(-5, min(5, pos_hits * 3 - neg_hits * 3))
+
+    def _generate_npc_reply(
+        self, npc: NPC, message: str, affection_delta: int
+    ) -> str:
+        """Produce a context-aware reply without external LLM calls."""
+
+        mood = npc.derive_mood()
+        if affection_delta > 0:
+            acknowledgement = "고마워요."
+        elif affection_delta < 0:
+            acknowledgement = "조금 마음이 상했어요."
+        else:
+            acknowledgement = "그렇군요."
+
+        templates: Dict[Mood, str] = {
+            Mood.HAPPY: (
+                "{ack} 오늘 기분이 좋아요! 별들도 당신 편인 것 같아요."
+            ),
+            Mood.NEUTRAL: "{ack} 마을 소식은 늘 조용하네요.",
+            Mood.TIRED: "{ack} 조금 쉬고 싶지만 이야기 나누는 건 좋아요.",
+            Mood.HUNGRY: "{ack} 배가 좀 고파서인지 집중이 잘 안 되네요.",
+            Mood.EXHAUSTED: "{ack} 오늘은 힘이 빠져서 대답이 늦을지도 몰라요.",
+        }
+        template = templates[mood]
+        reply = template.format(ack=acknowledgement)
+        if npc.role == "점성술사":
+            reply += " 별자리가 전하는 작은 조언도 곧 전해드릴게요."
+        elif npc.role == "상점 주인":
+            reply += " 가게에 신선한 물건이 들어왔답니다."
+        elif npc.role == "촌장":
+            reply += " 마을 사람들을 위해 더 나은 결정을 고민 중이죠."
+
+        if "도와" in message:
+            reply += " 언제든 도움이 필요하면 말씀하세요."
+        return reply
+
+    def _npc_background_conversations(self) -> None:
+        """Generate lightweight NPC to NPC chatter."""
+
+        npc_ids = list(self.npcs.keys())
+        if len(npc_ids) < 2:
+            return
+
+        speaker_id, target_id = random.sample(npc_ids, 2)
+        speaker = self.npcs[speaker_id]
+        target = self.npcs[target_id]
+
+        mood = speaker.derive_mood()
+        if mood == Mood.HAPPY:
+            text = f"{target.name}씨, 오늘 별빛이 특히 반짝여요!"
+        elif mood == Mood.HUNGRY:
+            text = f"{target.name}씨, 혹시 남는 간식이 있나요?"
+        elif mood == Mood.TIRED:
+            text = f"{target.name}씨, 오늘 일손이 좀 부족하네요."
+        else:
+            text = f"{target.name}씨, 마을 소식은 어떠세요?"
+
+        self.record_dialogue(speaker_id, text, target_id, tags={"type": "npc_chatter"})
+        target.adjust_affection(1)
+
+    def _apply_stat_changes(self) -> None:
+        """Apply passive stat drift to all NPCs."""
+
+        for npc in self.npcs.values():
+            npc.apply_daily_decay()
+
+    def _new_day_reset(self) -> None:
+        """Reset limited stats at the beginning of a day."""
+
+        for npc in self.npcs.values():
+            npc.stamina = min(100, npc.stamina + 20)
+            npc.hunger = max(0, npc.hunger - 20)
+            self.record_dialogue(
+                npc.npc_id,
+                "새로운 하루가 밝았어요. 모두 힘내봐요!",
+                tags={"type": "daily_greeting"},
+            )
+
+
+# Global singleton used by the API layer.
+STATE = GameState()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <title>LLM 마을 관찰 뷰</title>
+    <style>
+      body {
+        font-family: "Noto Sans KR", system-ui, sans-serif;
+        margin: 0;
+        padding: 0;
+        background: #f2efe8;
+        color: #1f2933;
+      }
+      header {
+        padding: 1.5rem;
+        background: #3a6b35;
+        color: white;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      main {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1.5rem;
+        padding: 1.5rem;
+      }
+      section {
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 8px 24px rgba(58, 107, 53, 0.08);
+        padding: 1rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        min-height: 200px;
+      }
+      h2 {
+        margin-top: 0;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        max-height: 320px;
+        overflow-y: auto;
+      }
+      li + li {
+        margin-top: 0.75rem;
+      }
+      .npc-card {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1rem;
+        border-radius: 10px;
+        background: #eef5ed;
+      }
+      .npc-card strong {
+        font-size: 1.1rem;
+      }
+      .mood {
+        font-size: 0.85rem;
+        color: #3a6b35;
+      }
+      .logs {
+        font-size: 0.95rem;
+        line-height: 1.4;
+      }
+      .logs time {
+        font-size: 0.8rem;
+        color: #738290;
+        display: block;
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-top: 1rem;
+      }
+      select,
+      textarea,
+      button {
+        padding: 0.75rem;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        font-size: 1rem;
+        font-family: inherit;
+      }
+      button {
+        background: #3a6b35;
+        color: white;
+        cursor: pointer;
+        border: none;
+        transition: background 0.2s ease-in-out;
+      }
+      button:hover {
+        background: #2b4f27;
+      }
+      .toast {
+        position: fixed;
+        bottom: 24px;
+        right: 24px;
+        background: #3a6b35;
+        color: white;
+        padding: 1rem 1.5rem;
+        border-radius: 8px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>LLM 농촌 마을</h1>
+      <button id="advance-time">시간 흐르게 하기</button>
+    </header>
+    <main>
+      <section>
+        <h2>NPC 현황</h2>
+        <ul id="npc-list"></ul>
+      </section>
+      <section>
+        <h2>대화 로그</h2>
+        <ul id="log-list" class="logs"></ul>
+      </section>
+      <section>
+        <h2>플레이어 대화</h2>
+        <form id="talk-form">
+          <label>
+            대화할 NPC
+            <select id="npc-select"></select>
+          </label>
+          <label>
+            메시지
+            <textarea id="message" rows="4" placeholder="따뜻한 말을 건네보세요"></textarea>
+          </label>
+          <button type="submit">대화하기</button>
+        </form>
+      </section>
+      <section>
+        <h2>시뮬레이션 상태</h2>
+        <div id="sim-status">1일차 0번째 시간</div>
+      </section>
+    </main>
+    <div id="toast" class="toast"></div>
+    <script>
+      const API_BASE = "/api";
+      const npcListEl = document.getElementById("npc-list");
+      const logListEl = document.getElementById("log-list");
+      const npcSelectEl = document.getElementById("npc-select");
+      const talkForm = document.getElementById("talk-form");
+      const messageEl = document.getElementById("message");
+      const advanceBtn = document.getElementById("advance-time");
+      const simStatusEl = document.getElementById("sim-status");
+      const toastEl = document.getElementById("toast");
+
+      async function fetchJSON(url, options) {
+        const response = await fetch(url, options);
+        if (!response.ok) {
+          throw new Error(`Request failed: ${response.status}`);
+        }
+        return await response.json();
+      }
+
+      function moodLabel(mood) {
+        const labels = {
+          happy: "😊 기쁨",
+          neutral: "🙂 보통",
+          tired: "😴 피곤",
+          hungry: "🍞 배고픔",
+          exhausted: "💤 탈진",
+        };
+        return labels[mood] || mood;
+      }
+
+      function renderNPCs(npcs) {
+        npcListEl.innerHTML = "";
+        npcSelectEl.innerHTML = "";
+        npcs.forEach((npc) => {
+          const li = document.createElement("li");
+          li.className = "npc-card";
+          li.innerHTML = `
+            <div>
+              <strong>${npc.name}</strong> <span class="mood">${moodLabel(npc.mood)}</span><br />
+              <small>${npc.role}</small>
+            </div>
+            <div>
+              ❤️ ${npc.affection} · 💪 ${npc.stamina} · 🍚 ${npc.hunger}
+            </div>
+          `;
+          npcListEl.appendChild(li);
+
+          const option = document.createElement("option");
+          option.value = npc.npc_id;
+          option.textContent = `${npc.name} (${npc.role})`;
+          npcSelectEl.appendChild(option);
+        });
+      }
+
+      function renderLogs(logs) {
+        logListEl.innerHTML = "";
+        logs
+          .slice()
+          .reverse()
+          .forEach((log) => {
+            const li = document.createElement("li");
+            const speaker = log.speaker_id === "player" ? "플레이어" : log.speaker_id;
+            const target = log.target_id
+              ? ` → ${log.target_id === "player" ? "플레이어" : log.target_id}`
+              : "";
+            li.innerHTML = `
+              <time>${new Date(log.timestamp).toLocaleTimeString()}</time>
+              <strong>${speaker}${target}</strong><br />
+              ${log.message}
+            `;
+            logListEl.appendChild(li);
+          });
+      }
+
+      function showToast(message) {
+        toastEl.textContent = message;
+        toastEl.style.display = "block";
+        setTimeout(() => {
+          toastEl.style.display = "none";
+        }, 2500);
+      }
+
+      async function refreshAll() {
+        const [npcData, logData] = await Promise.all([
+          fetchJSON(`${API_BASE}/npcs`),
+          fetchJSON(`${API_BASE}/logs?limit=40`),
+        ]);
+        renderNPCs(npcData.npcs);
+        renderLogs(logData.logs);
+      }
+
+      talkForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const npcId = npcSelectEl.value;
+        const message = messageEl.value.trim();
+        if (!message) {
+          showToast("메시지를 입력해주세요");
+          return;
+        }
+        const result = await fetchJSON(`${API_BASE}/interactions/user`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ npc_id: npcId, message }),
+        });
+        showToast(`${result.npc.name}의 반응: ${result.reply}`);
+        messageEl.value = "";
+        await refreshAll();
+      });
+
+      advanceBtn.addEventListener("click", async () => {
+        const result = await fetchJSON(`${API_BASE}/simulate/tick`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ steps: 1 }),
+        });
+        simStatusEl.textContent = `${result.day}일차 ${result.time_slice % 4}번째 시간`;
+        showToast("시간이 조금 흘렀습니다");
+        await refreshAll();
+      });
+
+      refreshAll();
+    </script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.1
+uvicorn[standard]==0.27.1


### PR DESCRIPTION
## Summary
- add FastAPI backend with in-memory NPC state, dialogue heuristics, and simulation loop
- provide simple HTML dashboard to inspect NPC stats, logs, and interact as a player
- document setup instructions and dependencies for running the prototype

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c960ac7fb0832cb56fe706412f9f8a